### PR TITLE
update requirements. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-langdetect==1.0.8
-nltk~=3.6.6
-pandas==1.0.3
+langdetect~=1.0.9
+nltk~=3.7
+pandas~=1.5.1
 numpy~=1.23.4
-pytesseract==0.3.9
-pdfplumber==0.6.0
-opencv-python==4.5.5.64
-Pillow==9.0.1
+pytesseract~=0.3.10
+pdfplumber~=0.7.5
+opencv-python~=4.5.5.64
+pillow~=9.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
 
+with open("requirements.txt", "r") as f:
+    required = f.read().splitlines()
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
     name="ai-data-preprocessing-queue",
-    version="1.2.1",
+    version="1.3.0",
     description="Can be used to pre process data before ai processing",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SamhammerAG/ai-data-preprocessing-queue",
     packages=find_packages(exclude=["test_data"]),
-    install_requires=["langdetect==1.0.8", "nltk~=3.6.6", "pandas==1.0.3", "numpy~=1.23.4", "pytesseract == 0.3.9",
-                      "pdfplumber== 0.6.0", "opencv-python==4.5.5.64", "Pillow==9.0.1"]
+    install_requires=required
 )


### PR DESCRIPTION
Only opencv-python is outdated, there is a bug while import cv2, we can use 4.6.0.66, wenn using python 3.10.

PLEASE: tag as 1.3.0 after merge in to master
Only Clusterizer could use this version in the moment